### PR TITLE
Fix header case sensitivity bug and some other minor changes

### DIFF
--- a/HTTPSBridge.cpp
+++ b/HTTPSBridge.cpp
@@ -29,7 +29,7 @@ void HTTPSBridge::buildRequestFromHeaders(HttpHeaders &headers, std::string &req
 	  << "HTTP/1.0\r\n";
       
   std::map<std::string,std::string>::iterator iter;
-  std::map<std::string,std::string>& headersMap = headers.getHeaders();
+  std::map<std::string,std::string,ci_less>& headersMap = headers.getHeaders();
   for( iter = headersMap.begin(); iter != headersMap.end(); ++iter ) {
     std::string key   = iter->first;
     std::string value = iter->second;

--- a/HTTPSBridge.cpp
+++ b/HTTPSBridge.cpp
@@ -50,7 +50,6 @@ void HTTPSBridge::buildRequestFromHeaders(HttpHeaders &headers, std::string &req
 bool HTTPSBridge::readFromClient() {
   char buf[4096];
   int bytesRead;
-  int bytesWritten;
 
   do {
     if ((bytesRead = SSL_read(clientSession, buf, sizeof(buf))) <= 0) 

--- a/certificate/Certificate.hpp
+++ b/certificate/Certificate.hpp
@@ -57,7 +57,7 @@ private:
     int forwardSlash = url.find('/', 7);
 
     if (forwardSlash) forwardSlash -= 7;
-    else              forwardSlash  = std::string::npos;
+    else              forwardSlash  = (int) std::string::npos;
 
     std::string name = url.substr(7, forwardSlash);	
     

--- a/certificate/CertificateManager.cpp
+++ b/certificate/CertificateManager.cpp
@@ -23,6 +23,8 @@ Certificate* CertificateManager::readCredentialsFromFile(const path &file, bool 
   X509 *cert    = loadCertificateFromFile(system_complete(file).string().c_str());
   EVP_PKEY *key = loadKeyFromFile(system_complete(file).string().c_str());
 
+  if (!cert || !key) throw BadCertificateException();
+
   return new Certificate(cert, key, resolve);
 }
 

--- a/http/HttpHeaders.cpp
+++ b/http/HttpHeaders.cpp
@@ -22,7 +22,7 @@
 #include "../Logger.hpp"
 
 
-std::map<std::string, std::string>& HttpHeaders::getHeaders() {
+std::map<std::string, std::string, ci_less>& HttpHeaders::getHeaders() {
   return headers;
 }
 

--- a/http/HttpHeaders.hpp
+++ b/http/HttpHeaders.hpp
@@ -37,6 +37,27 @@ public:
   }
 };
 
+/************************************************************************/
+/* Comparator for case-insensitive comparison in STL assos. containers  */
+/************************************************************************/
+struct ci_less : std::binary_function<std::string, std::string, bool>
+{
+  // case-independent (ci) compare_less binary function
+  struct nocase_compare : public std::binary_function<unsigned char,unsigned char,bool> 
+  {
+    bool operator() (const unsigned char& c1, const unsigned char& c2) const {
+        return tolower (c1) < tolower (c2);
+    }
+  };
+  bool operator() (const std::string & s1, const std::string & s2) const {
+    return std::lexicographical_compare
+      (s1.begin (), s1.end (),   // source range
+      s2.begin (), s2.end (),   // dest range
+      nocase_compare ());  // comparison
+  }
+};
+
+
 class HttpHeaders {
 
 private:
@@ -52,7 +73,7 @@ private:
   std::string postData;
   std::string key;
   std::string value;
-  std::map<std::string, std::string> headers;
+  std::map<std::string, std::string, ci_less> headers;
 
   int readLine(char *buffer, int *offset, int length);
   int readAction(char *buffer, int length);
@@ -71,7 +92,7 @@ public:
   bool process(char * buffer, int length);
   bool isPost();
 
-  std::map<std::string, std::string>& getHeaders();
+  std::map<std::string, std::string, ci_less>& getHeaders();
   std::string& getHeader(std::string& header);
   std::string& getMethod();
   std::string& getRequest();  


### PR DESCRIPTION
Some proposed changes:
- http header field names are case insensitive (RFC2616, sec 4.2): added a case insensitive compare func to header std::map. this fixes problems with certain web servers such as Oracle-iPlanet-Web-Server
- don't crash if certificate loading fails
- fixed a warning and removed an unused variable
