### PR TITLE
Fix build on BSD by reordering includes

### DIFF
--- a/util/Destination.cpp
+++ b/util/Destination.cpp
@@ -21,6 +21,8 @@
 //#define HAVE_PF 
 #define HAVE_NETFILTER 
 
+#include "util/Destination.hpp"
+
 #include <arpa/inet.h>
 
 #ifdef HAVE_NETFILTER
@@ -37,9 +39,6 @@
 #include <netinet/in.h>
 #include <net/pfvar.h>
 #endif
-
-
-#include "util/Destination.hpp"
 
 int Destination::getOriginalDestination(boost::asio::ip::tcp::socket &socket,
 					boost::asio::ip::tcp::endpoint &originalDestination)


### PR DESCRIPTION
Boost headers fail to compile if "struct ip" is declared when
including them.  Fix build by including Destination.hpp before
any of the BSD pf related headers.
