### PR TITLE
Autodetect Linux netfilter and BSD pf

### DIFF
--- a/README
+++ b/README
@@ -14,9 +14,8 @@ The three steps to get this running are:
 Installing sslsniff
 -------------------
 
-    * Unpack sslsniff-0.8.tar.gz, run "./configure" and "make". (You'll have
-      to make some changes to build on BSD systems, see below under "Setting up 
-      pf")
+    * Unpack sslsniff-0.8.tar.gz, run "./configure" and "make". On BSD systems,
+      you'll have to pass --enable-pf to configure.
     * There are two ways to run this: in "authority" mode or "targeted" mode.
 
     Authority Mode:
@@ -103,10 +102,8 @@ Setting up iptables
 Setting up pf
 -------------
 
-Basic support for pf is now included. Set up firewall rules similar to
-those above, and change util/Destination.cpp by undefining HAVE_NETFILTER
-and defining HAVE_PF at the top.
-
+Basic support for pf is now included when passing "--enable-pf" to
+configure when building. Set up firewall rules similar to those above.
 
 Running arpspoof
 --------------------------

--- a/README
+++ b/README
@@ -14,8 +14,7 @@ The three steps to get this running are:
 Installing sslsniff
 -------------------
 
-    * Unpack sslsniff-0.8.tar.gz, run "./configure" and "make". On BSD systems,
-      you'll have to pass --enable-pf to configure.
+    * Unpack sslsniff-0.8.tar.gz, run "./configure" and "make".
     * There are two ways to run this: in "authority" mode or "targeted" mode.
 
     Authority Mode:
@@ -102,8 +101,8 @@ Setting up iptables
 Setting up pf
 -------------
 
-Basic support for pf is now included when passing "--enable-pf" to
-configure when building. Set up firewall rules similar to those above.
+Support for pf is now automatically included on BSD systems.
+Set up firewall rules similar to those above.
 
 Running arpspoof
 --------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -19,4 +19,10 @@ AC_CHECK_HEADER([boost/thread.hpp],
 AC_CHECK_HEADER([openssl/ssl.h],
 	[],
 	AC_MSG_ERROR([openssl (libssl-dev) library not installed.]))
+AC_ARG_ENABLE(pf,
+	AS_HELP_STRING([--enable-pf],
+	               [Enable BSD pf support instead of Linux netfilter]),,)
+if test "x$enable_pf" = "xyes"; then
+	CPPFLAGS="-DHAVE_PF $CPPFLAGS"
+fi
 AC_OUTPUT(Makefile)

--- a/configure.ac
+++ b/configure.ac
@@ -19,10 +19,23 @@ AC_CHECK_HEADER([boost/thread.hpp],
 AC_CHECK_HEADER([openssl/ssl.h],
 	[],
 	AC_MSG_ERROR([openssl (libssl-dev) library not installed.]))
+
+AC_CHECK_HEADER([net/pfvar.h],[natapi="pf"],,[-])
+AC_CHECK_HEADER([linux/netfilter_ipv4.h],[natapi="netfilter"],,[-])
 AC_ARG_ENABLE(pf,
 	AS_HELP_STRING([--enable-pf],
-	               [Enable BSD pf support instead of Linux netfilter]),,)
-if test "x$enable_pf" = "xyes"; then
+	               [Enable BSD pf support, overriding autodetection]),
+	               [natapi="pf"],)
+case "$natapi" in
+netfilter)
+	CPPFLAGS="-DHAVE_NETFILTER $CPPFLAGS"
+	;;
+pf)
 	CPPFLAGS="-DHAVE_PF $CPPFLAGS"
-fi
+	;;
+*)
+	AC_MSG_ERROR([neither Linux NetFilter nor BSD pf detected.])
+	;;
+esac
+
 AC_OUTPUT(Makefile)

--- a/util/Destination.cpp
+++ b/util/Destination.cpp
@@ -17,9 +17,9 @@
  * USA
  */
 
-// XXX define one of these through autoconf
-//#define HAVE_PF 
+#if !defined(HAVE_NETFILTER) && !defined(HAVE_PF)
 #define HAVE_NETFILTER 
+#endif
 
 #include <arpa/inet.h>
 


### PR DESCRIPTION
Automatically detect the right NAT state table API to use
using appropriate autoconfig magic.
