### PR TITLE
Parse CN from DN using OpenSSL facilities

### DIFF
--- a/SSLBridge.cpp
+++ b/SSLBridge.cpp
@@ -57,17 +57,13 @@ ip::tcp::endpoint SSLBridge::getRemoteEndpoint() {
 }
 
 void SSLBridge::setServerName() {
-  X509 *serverCertificate    = getServerCertificate();
-  X509_NAME *serverNameField = X509_get_subject_name(serverCertificate);
-  char *serverNameStr        = X509_NAME_oneline(serverNameField, NULL, 0);
-
-  this->serverName = std::string((const char*)serverNameStr);
-  int commonNameIndex;
-
-  if ((commonNameIndex = this->serverName.find("CN=")) != std::string::npos)
-    this->serverName = this->serverName.substr(commonNameIndex+3);
-  
-  free(serverNameStr);
+  X509 *serverCertificate = getServerCertificate();
+  X509_NAME *ptr = X509_get_subject_name(serverCertificate);
+  int sz = X509_NAME_get_text_by_NID(ptr, NID_commonName, NULL, 0) + 1;
+  char *commonNameStr = (char*)malloc(sz);
+  X509_NAME_get_text_by_NID(ptr, NID_commonName, commonNameStr, sz);
+  this->serverName = std::string((const char*)commonNameStr);
+  free(commonNameStr);
 }
 
 void SSLBridge::handshakeWithClient(CertificateManager &manager, bool wildcardOK) {

--- a/certificate/Certificate.hpp
+++ b/certificate/Certificate.hpp
@@ -92,16 +92,12 @@ private:
   }
 
   void parseCommonName(X509 *cert) {
-    std::string distinguishedName(cert->name);
-    std::string::size_type cnIndex = distinguishedName.find("CN=");
-
-    if (cnIndex == std::string::npos) throw BadCertificateException();
-
-    std::string commonName           = distinguishedName.substr(cnIndex+3);    
-    std::string::size_type nullIndex = commonName.find("\\x00");
-    
-    if (nullIndex != std::string::npos) this->name = commonName.substr(0, nullIndex);
-    else                                this->name = commonName;
+    X509_NAME *ptr = X509_get_subject_name(cert);
+    int sz = X509_NAME_get_text_by_NID(ptr, NID_commonName, NULL, 0) + 1;
+    char *commonNameStr = (char*)malloc(sz);
+    X509_NAME_get_text_by_NID(ptr, NID_commonName, commonNameStr, sz);
+    this->name = std::string((const char*)commonNameStr);
+    free(commonNameStr);
   }
 
 public:


### PR DESCRIPTION
Use OpenSSL facilities to parse the CN from the DN.  This allows to
correctly parse certificates which have additional DN components after
the CN, such as "emailAddress".  The manual parsing included additional
components following the CN as part of the common name, which in turn
lead to DNS lookups for malformed domain names such as
"www.example.com/emailAddress=jdoe@example.com.example.org".

Fixes issue #12 reported by ju916
