### PR TITLE
Fix wildcard certificate detection

### DIFF
--- a/certificate/Certificate.hpp
+++ b/certificate/Certificate.hpp
@@ -177,7 +177,7 @@ public:
   }
 
   bool isWildcard() {
-    return name == "*";
+    return name[0] == '*';
   }
 };
 


### PR DESCRIPTION
Make the wildcard certificate detection code actually work.
This prevents sslsniff from attempting to resolve wildcard
domain names to IP addresses and then crash after failing.

Fixes #13 and possibly #11.
