### PR TITLE
Off by one error in readAction. For example, let buffer = 'G' and length...

### DIFF
--- a/http/HttpHeaders.cpp
+++ b/http/HttpHeaders.cpp
@@ -89,7 +89,7 @@ int HttpHeaders::readAction(char *buffer, int length) {
   int offset   = 0;
   int complete = readLine(buffer, &offset, length);
 
-  action.append(buffer, offset+1);
+  action.append(buffer, offset);
 
   if (complete) {
     parseAction();


### PR DESCRIPTION
... = 1, when readLine completes offset will also be 1. If we then try to append append(buffer, 2), we'll get a null char in our action, which will cause the SSL_write in HTTPSBridge.cpp to terminate early.

Tested on ubuntu 11.04 with linux 2.6.35.
